### PR TITLE
fix(docs): correct env var name to ICE_COLOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ ice also supports all the standard kubectl flags in addition to:
 Flags:
   -A, --all-namespaces                 List containers from pods in all namespaces
       --annotation string              Show the selected annotation as a column
-      --color string                   Add some much needed colour to the table output. string can be one of: columns, custom, errors, mix and none (overrides environment variable ICE_COLOUR)
+      --color string                   Add some much needed colour to the table output. string can be one of: columns, custom, errors, mix and none (overrides environment variable ICE_COLOR)
   -c, --container string               Container name. If set shows only the named containers
       --context string                 The name of the kubeconfig context to use
   -m, --match string                   Filters out results, comma seperated list of COLUMN OP VALUE, where OP can be one of ==,<,>,<=,>= and != 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -420,7 +420,7 @@ func addCommonFlags(cmdObj *cobra.Command) {
 	cmdObj.Flags().StringP("annotation", "", "", `Show the selected annotation as a column`)
 	cmdObj.Flags().StringP("filename", "f", "", `read pod information from this yaml file instead`)
 	cmdObj.Flags().StringP("columns", "", "", `list of column names to show in the table output, all other columns are hidden`)
-	cmdObj.Flags().StringP("color", "", "", `Add some much needed colour to the table output. string can be one of: columns, custom, errors, mix and none (overrides env variable ICE_COLOUR)`)
+	cmdObj.Flags().StringP("color", "", "", `Add some much needed colour to the table output. string can be one of: columns, custom, errors, mix and none (overrides env variable ICE_COLOR)`)
 }
 
 func processCommonFlags(cmd *cobra.Command) (commonFlags, error) {


### PR DESCRIPTION
The code reads env var ICE_COLOUR, but help and README docs say it's ICE_COLOUR. Correct the documentation to match the code behaviour.